### PR TITLE
chore(release): v2.1.0 [skip ci]

### DIFF
--- a/.github/scripts/normalize-changelog-header.cjs
+++ b/.github/scripts/normalize-changelog-header.cjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+const child_process = require('node:child_process')
+const fs = require('node:fs')
+
+const changelogPath = 'CHANGELOG.md'
+
+function normalizeChangelogHeader(content) {
+  const headerStart = content.indexOf('# Changelog\n')
+  if (headerStart <= 0) {
+    return content
+  }
+
+  const nextSectionStart = content.indexOf('\n## ', headerStart + 1)
+  const headerBlock = (nextSectionStart === -1 ? content.slice(headerStart) : content.slice(headerStart, nextSectionStart)).trim()
+  const prependedEntries = content.slice(0, headerStart).trim()
+  const remainingEntries = (nextSectionStart === -1 ? '' : content.slice(nextSectionStart)).trim()
+
+  return [headerBlock, prependedEntries, remainingEntries].filter(Boolean).join('\n\n') + '\n'
+}
+
+function getRepoUrl() {
+  try {
+    const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+    let url = (typeof pkg.repository === 'string' ? pkg.repository : pkg.repository?.url) || ''
+    url = url.replace(/^git\+/, '').replace(/\.git$/, '')
+    if (url.startsWith('https://')) return url
+  } catch {}
+  try {
+    const remote = child_process.execSync('git remote get-url origin').toString().trim()
+    return remote.replace(/^git\+/, '').replace(/\.git$/, '').replace(/^git@github\.com:/, 'https://github.com/')
+  } catch {}
+  return ''
+}
+
+function getPreviousTag() {
+  try {
+    const tags = child_process
+      .execSync('git tag --sort=-version:refname')
+      .toString()
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+    return tags[0] || ''
+  } catch {
+    return ''
+  }
+}
+
+function appendFullChangelogLink(content, currentTag, repoUrl) {
+  const prefix = `**Full Changelog**: ${repoUrl}/compare/`
+  // Find the bounds of the first release section (the newly generated one)
+  const firstSectionStart = content.indexOf('\n## ')
+  if (firstSectionStart === -1) return content
+  const firstSectionEnd = content.indexOf('\n## ', firstSectionStart + 1)
+  const firstSection = firstSectionEnd === -1 ? content.slice(firstSectionStart) : content.slice(firstSectionStart, firstSectionEnd)
+
+  // Skip if a Full Changelog link is already present in that section
+  if (firstSection.includes(prefix)) return content
+
+  const prevTag = getPreviousTag()
+  if (!prevTag) return content
+
+  const link = `**Full Changelog**: ${repoUrl}/compare/${prevTag}...${currentTag}`
+  if (firstSectionEnd === -1) {
+    return content.trimEnd() + '\n\n' + link + '\n'
+  }
+  return content.slice(0, firstSectionEnd).trimEnd() + '\n\n' + link + '\n' + content.slice(firstSectionEnd)
+}
+
+exports.preCommit = (props) => {
+  if (!fs.existsSync(changelogPath)) {
+    return
+  }
+
+  let content = fs.readFileSync(changelogPath, 'utf8')
+  content = normalizeChangelogHeader(content)
+
+  const repoUrl = getRepoUrl()
+  const currentTag = props?.tag || ''
+  if (repoUrl && currentTag) {
+    content = appendFullChangelogLink(content, currentTag, repoUrl)
+  }
+
+  fs.writeFileSync(changelogPath, content)
+}

--- a/.github/scripts/npm-version-script-esm-auto.js
+++ b/.github/scripts/npm-version-script-esm-auto.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+/**
+ * Standalone ESM implementation — self-contained so this file can be copied
+ * into other repos without pulling any other files.
+ */
+
+import assert from 'node:assert'
+import child_process from 'node:child_process'
+import fs from 'node:fs'
+import process from 'node:process'
+// Minimal, in-file semver utilities used by this script.
+// This avoids an external dependency so the script can run in environments
+// where `semver` isn't installed.
+const semver = {
+	// Very small validation: match major.minor.patch with optional prerelease/build
+	valid(v) {
+		return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/.test(v)
+	},
+	// Return prerelease identifiers array or null
+	prerelease(v) {
+		const m = v.match(/^\d+\.\d+\.\d+-(.+)$/)
+		return m ? m[1].split('.') : null
+	},
+	// Compare two semver strings in reverse order (for rcompare use)
+	rcompare(a, b) {
+		// Use standard semver precedence rules for major.minor.patch; ignore prerelease complexity except that prerelease is lower than release
+		const pa = a.split('-')
+		const pb = b.split('-')
+		const aCore = pa[0].split('.').map(Number)
+		const bCore = pb[0].split('.').map(Number)
+		for (let i = 0; i < 3; i++) {
+			if (aCore[i] > bCore[i]) return -1
+			if (aCore[i] < bCore[i]) return 1
+		}
+		// equal core; releases (no prerelease) are greater than prerelease
+		if (pa.length === 1 && pb.length > 1) return -1
+		if (pa.length > 1 && pb.length === 1) return 1
+		// both same prerelease status: compare as strings
+		if (a > b) return -1
+		if (a < b) return 1
+		return 0
+	},
+	// Increment version by 'major'|'minor'|'patch'
+	inc(v, level) {
+		if (!this.valid(v)) throw new Error(`Invalid semver passed to inc: ${v}`)
+		// strip prerelease/build
+		const core = v.split('-')[0].split('+')[0]
+		const parts = core.split('.').map(Number)
+		switch (level) {
+			case 'major':
+				parts[0] += 1
+				parts[1] = 0
+				parts[2] = 0
+				break
+			case 'minor':
+				parts[1] += 1
+				parts[2] = 0
+				break
+			case 'patch':
+			default:
+				parts[2] += 1
+				break
+		}
+		return parts.join('.')
+	}
+}
+
+const BRANCH_VERSION_PATTERN = /^([A-Z]+)-(\d+\.\d+\.\d+)$/i
+
+// Load package.json
+const packageJSON = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+
+const refArgument = process.argv[2]
+const tagArgument = process.argv[3] || 'latest'
+
+if (!refArgument) {
+	console.error('ref argument is missing')
+	console.error('Usage: npm-version-script-esm.js <ref> [tag]')
+	process.exit(1)
+}
+
+/**
+ * Queries the NPM registry for the latest version for the provided base version and tag.
+ * If the tag is latest, then the base version is returned if it exists. For other tags, the latest
+ * version found for that base version and tag is returned.
+ * @param baseVersion The base version to query for, e.g. 2.0.0
+ * @param tag The tag to query for, e.g. beta or latest
+ * @returns {string} Returns the version, or '' if not found
+ */
+function getTagVersionFromNpm(baseVersion, tag) {
+	try {
+		return JSON.parse(child_process.execSync(`npm info ${packageJSON.name} versions --json`).toString('utf8').trim())
+			.filter(v => (tag === 'latest' ? v === baseVersion : v.startsWith(`${baseVersion}-${tag}.`)))
+			.reduce((_, current) => current, '')
+	} catch (e) {
+		console.error(`Failed to query the npm registry for the latest version for tag: ${tag}`, e)
+		// throw e;
+		return ''
+	}
+}
+
+function getLatestStableVersionFromNpm() {
+	try {
+		const versions = JSON.parse(child_process.execSync(`npm info ${packageJSON.name} versions --json`).toString('utf8').trim())
+		if (!Array.isArray(versions) || versions.length === 0) return ''
+
+		// Only consider stable semver versions (no prerelease)
+		const stable = versions.filter(v => semver.valid(v) && !semver.prerelease(v))
+		if (stable.length === 0) return ''
+
+		// Sort descending and return the highest
+		const sorted = stable.sort(semver.rcompare)
+		return sorted[0]
+	} catch (e) {
+		console.error('Failed to query the npm registry for published versions', e)
+		return ''
+	}
+}
+
+function desiredTargetVersion(ref) {
+	// ref is a GitHub action ref string
+	if (ref.startsWith('refs/pull/')) {
+		throw new Error('The version script was executed inside a PR!')
+	}
+
+	assert(ref.startsWith('refs/heads/'))
+	const branchName = ref.slice('refs/heads/'.length)
+
+	const results = branchName.match(BRANCH_VERSION_PATTERN)
+	if (results !== null) {
+		if (results[1].toLowerCase() !== tagArgument.toLowerCase()) {
+			console.warn(`The base branch name (${results[1]}) differs from the tag name ${tagArgument}`)
+		}
+
+		return results[2]
+	}
+
+	if (branchName === 'latest') {
+		// For latest branch, start with package.json version as base
+		return packageJSON.version
+	}
+
+	throw new Error(`Malformed branch name for ref: ${ref}. Must be beta-x.x.x, alpha-x.x.x, or 'latest'`)
+}
+
+function bumpVersion(baseVersion, level) {
+	const normalizedLevel = (level || 'patch').toLowerCase()
+	if (!semver.valid(baseVersion)) {
+		throw new Error(`Invalid base version passed to bumpVersion: ${baseVersion}`)
+	}
+
+	switch (normalizedLevel) {
+		case 'major':
+			return semver.inc(baseVersion, 'major')
+		case 'minor':
+			return semver.inc(baseVersion, 'minor')
+		case 'patch':
+		default:
+			return semver.inc(baseVersion, 'patch')
+	}
+}
+
+const baseVersion = desiredTargetVersion(refArgument)
+let publishTag = baseVersion
+
+if (refArgument.includes('latest')) {
+	// For latest branch, determine next version based on npm and bump patch.
+	const latestPublishedStable = getLatestStableVersionFromNpm()
+	if (latestPublishedStable) {
+		console.warn(`Latest published stable version is ${latestPublishedStable}; bumping patch`)
+		publishTag = bumpVersion(latestPublishedStable, 'patch')
+	} else {
+		console.warn('No published stable versions found; bumping package.json version patch')
+		publishTag = bumpVersion(baseVersion, 'patch')
+	}
+} else {
+	// For alpha/beta, query npm for latest
+	const latestReleasedVersion = getTagVersionFromNpm(baseVersion, tagArgument)
+	if (latestReleasedVersion) {
+		console.warn(`Latest published version for ${baseVersion} with tag ${tagArgument} is ${latestReleasedVersion}`)
+		publishTag = latestReleasedVersion
+	} else {
+		console.warn(`No published versions for ${baseVersion} with tag ${tagArgument}`)
+	}
+}
+
+if (packageJSON.version !== publishTag) {
+	console.warn(`Updating version in package.json from ${packageJSON.version} to ${publishTag}`)
+	packageJSON.version = publishTag
+	fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2))
+
+	// perform the same change to the package-lock.json
+	const packageLockJSON = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'))
+	packageLockJSON.version = publishTag
+	fs.writeFileSync('package-lock.json', JSON.stringify(packageLockJSON, null, 2))
+} else {
+	console.warn(`Version in package.json is already ${packageJSON.version}`)
+}
+
+console.log(publishTag)

--- a/.github/scripts/resolve-version-bump-esm.js
+++ b/.github/scripts/resolve-version-bump-esm.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import https from 'node:https'
+import process from 'node:process'
+
+const allowed = new Set(['major', 'minor', 'patch'])
+
+function setOutput(name, value) {
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`)
+  }
+  console.log(`${name}=${value}`)
+}
+
+function resolveFromLabels(labels) {
+  const majorLabels = new Set(['major', 'semver:major', 'release:major', 'breaking', 'breaking-change'])
+  const minorLabels = new Set(['minor', 'semver:minor', 'release:minor', 'feature'])
+  const patchLabels = new Set(['patch', 'semver:patch', 'release:patch', 'fix'])
+
+  if (labels.some(label => majorLabels.has(label))) return 'major'
+  if (labels.some(label => minorLabels.has(label))) return 'minor'
+  if (labels.some(label => patchLabels.has(label))) return 'patch'
+  return 'patch'
+}
+
+function listPrsForCommit(owner, repo, sha, token) {
+  return new Promise((resolve, reject) => {
+    const path = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits/${sha}/pulls`
+    const req = https.request(
+      {
+        hostname: 'api.github.com',
+        method: 'GET',
+        path,
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'User-Agent': 'homebridge-resolve-version-bump',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+      (res) => {
+        let body = ''
+        res.setEncoding('utf8')
+        res.on('data', (chunk) => {
+          body += chunk
+        })
+        res.on('end', () => {
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`GitHub API request failed (${res.statusCode}): ${body}`))
+            return
+          }
+          try {
+            const parsed = JSON.parse(body)
+            resolve(Array.isArray(parsed) ? parsed : [])
+          } catch (error) {
+            reject(new Error(`Failed to parse GitHub API response: ${error.message}`))
+          }
+        })
+      },
+    )
+
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+async function main() {
+  const manualInput = (process.argv[2] || '').trim().toLowerCase()
+  if (manualInput) {
+    if (!allowed.has(manualInput)) {
+      console.error(`Invalid version bump '${manualInput}'. Use major, minor, or patch.`)
+      process.exit(1)
+    }
+    console.error(`Using manual version bump input: ${manualInput}`)
+    setOutput('version_bump', manualInput)
+    return
+  }
+
+  const repository = process.env.GITHUB_REPOSITORY || ''
+  const sha = process.env.GITHUB_SHA || ''
+  const token = process.env.GITHUB_TOKEN || ''
+
+  if (!repository || !sha || !token || !repository.includes('/')) {
+    console.error('Missing GITHUB_REPOSITORY, GITHUB_SHA, or GITHUB_TOKEN. Defaulting to patch.')
+    setOutput('version_bump', 'patch')
+    return
+  }
+
+  const [owner, repo] = repository.split('/')
+
+  try {
+    const prs = await listPrsForCommit(owner, repo, sha, token)
+    const pr = prs.find((candidate) => candidate.merged_at) || prs[0]
+
+    if (!pr) {
+      console.error('No PR associated with commit; defaulting to patch.')
+      setOutput('version_bump', 'patch')
+      return
+    }
+
+    const labels = (pr.labels || [])
+      .map((label) => (typeof label === 'string' ? label : label.name || ''))
+      .map((label) => label.toLowerCase())
+
+    const bump = resolveFromLabels(labels)
+    console.error(`Resolved bump '${bump}' from PR #${pr.number} labels: ${labels.join(', ') || '(none)'}`)
+    setOutput('version_bump', bump)
+  } catch (error) {
+    console.error(`Failed to inspect PR labels, defaulting to patch: ${error.message}`)
+    setOutput('version_bump', 'patch')
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## [2.1.0](https://github.com/homebridge-plugins/homebridge-meater/releases/tag/v2.1.0) (2026-05-04)

## What's Changed
* chore(release): prepare v2.1.0 release groundwork
* chore(deps): housekeeping and lockfile maintenance
* feat(matter): add Homebridge Matter support with HAP fallback
* test(matter): add config-gated fallback and selection coverage
* refactor(http): replace undici with native Node HTTP(S) requests
* chore(release): align workflow, config, and changelog for v2.1.0

Automatic Matter selection now uses Homebridge runtime availability only, with HAP fallback when Matter is unavailable.

**Full Changelog**: https://github.com/homebridge-plugins/homebridge-meater/compare/v2.0.3...v2.1.0
