### PR TITLE
V2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * test(matter): add config-gated fallback and selection coverage
 * refactor(http): replace undici with native Node HTTP(S) requests
 * chore(release): align workflow, config, and changelog for v2.1.0
+* fix(device): ensure Cook Refresh switch service is created before characteristic updates (PR #28, PR #33)
+* fix(auth): improve API authentication flow, persist token, and improve discovery logging (PR #35)
+* fix(temperature): clamp probe temperatures to HomeKit valid range to prevent characteristic validation errors (PR #36)
+* test(device): add unit tests for temperature clamping behavior (PR #36)
+* docs(workflow): add Copilot beta-branch workflow documentation (PR #34)
 
 Automatic Matter selection now uses Homebridge runtime availability only, with HAP fallback when Matter is unavailable.
 

--- a/docs/copilot-workflow.md
+++ b/docs/copilot-workflow.md
@@ -1,0 +1,112 @@
+# GitHub Copilot Beta Branch Workflow
+
+This document explains the new workflow implemented for GitHub Copilot to ensure proper semantic versioning and beta branch targeting.
+
+## Overview
+
+All GitHub Copilot-generated PRs now target beta branches instead of the main branch, ensuring a proper review and testing process before merging to production.
+
+## Workflow Changes
+
+### 1. Issue Labeling (Required Before Copilot Assignment)
+
+Before assigning any issue to GitHub Copilot, **one of these labels must be applied**:
+
+- `patch` - Bug fixes (2.0.2 → 2.0.3)
+- `minor` - New features (2.0.2 → 2.1.0)  
+- `major` - Breaking changes (2.0.2 → 3.0.0)
+
+### 2. Automatic Beta Branch Targeting
+
+GitHub Copilot will now:
+
+1. Check the issue label to determine version increment
+2. Calculate the target version based on current package.json version
+3. Look for an existing `beta-{version}` branch
+4. Create the beta branch if it doesn't exist
+5. Target the PR to the beta branch
+6. Update package.json to the target version
+
+### 3. Issue Templates Updated
+
+Issue templates have been updated to automatically apply appropriate labels:
+
+- **Bug Report** → `patch` label
+- **Feature Request** → `minor` label  
+- **Breaking Change Request** → `major` label
+
+## Beta Branch Management
+
+### Creating Beta Branches Manually
+
+If you need to create a beta branch manually:
+
+```bash
+# For patch release
+git checkout latest
+git pull origin latest  
+git checkout -b beta-2.0.3
+git push origin beta-2.0.3
+
+# For minor release
+git checkout latest
+git pull origin latest
+git checkout -b beta-2.1.0
+git push origin beta-2.1.0
+
+# For major release
+git checkout latest
+git pull origin latest
+git checkout -b beta-3.0.0
+git push origin beta-3.0.0
+```
+
+### Merging Beta Branches
+
+After testing and review, beta branches should be merged to `latest`:
+
+```bash
+git checkout latest
+git pull origin latest
+git merge beta-2.0.3
+git push origin latest
+git tag v2.0.3
+git push origin v2.0.3
+```
+
+## Files Added/Modified
+
+- `.github/copilot-instructions.md` - Main Copilot instructions
+- `.github/ISSUE_TEMPLATE/bug-report.yml` - Updated to use `patch` label
+- `.github/ISSUE_TEMPLATE/feature-request.yml` - Updated to use `minor` label
+- `.github/ISSUE_TEMPLATE/breaking-change.yml` - New template for `major` changes
+- `.github/pull_request_template.md` - New PR template with beta branch requirements
+- `docs/copilot-workflow.md` - This documentation file
+
+## Benefits
+
+1. **Proper Semantic Versioning**: Automatic version management based on change type
+2. **Beta Testing**: Changes go through beta branches for testing before production
+3. **Clear Process**: Standardized workflow for all contributors
+4. **Automated Branch Management**: Reduces manual branch creation and targeting errors
+
+## Troubleshooting
+
+### Issue has no version label
+
+If Copilot encounters an issue without a required label:
+1. The maintainer should add the appropriate label (`patch`, `minor`, or `major`)
+2. Then assign the issue to Copilot
+
+### Beta branch already exists
+
+If a beta branch already exists for the target version:
+- Copilot will target the existing branch
+- Multiple PRs can target the same beta branch
+
+### Version conflicts
+
+If there are version conflicts, the maintainer should:
+1. Resolve the conflict manually
+2. Update the issue label if needed
+3. Re-assign to Copilot if necessary

--- a/src/device/meater.test.ts
+++ b/src/device/meater.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Test the clampTemperature method logic without requiring full HomeKit setup
+ */
+describe('temperature Clamping Logic', () => {
+  // Helper function to test temperature clamping logic
+  function clampTemperature(temperature: number): number {
+    const minTemp = -270
+    const maxTemp = 100
+
+    if (temperature > maxTemp) {
+      return maxTemp
+    }
+
+    if (temperature < minTemp) {
+      return minTemp
+    }
+
+    return temperature
+  }
+
+  it('should clamp temperature above 100°C to 100°C', () => {
+    expect(clampTemperature(212)).toBe(100) // Grill ambient temp
+    expect(clampTemperature(150)).toBe(100) // High oven temp
+    expect(clampTemperature(100.1)).toBe(100) // Just over limit
+  })
+
+  it('should clamp temperature below -270°C to -270°C', () => {
+    expect(clampTemperature(-300)).toBe(-270)
+    expect(clampTemperature(-1000)).toBe(-270)
+    expect(clampTemperature(-270.1)).toBe(-270)
+  })
+
+  it('should not clamp temperatures within valid range', () => {
+    expect(clampTemperature(100)).toBe(100) // At maximum
+    expect(clampTemperature(-270)).toBe(-270) // At minimum
+    expect(clampTemperature(0)).toBe(0) // Freezing
+    expect(clampTemperature(25)).toBe(25) // Room temp
+    expect(clampTemperature(65)).toBe(65) // Cooking temp
+    expect(clampTemperature(85)).toBe(85) // High but valid
+  })
+
+  it('should handle edge cases', () => {
+    expect(clampTemperature(99.9)).toBe(99.9)
+    expect(clampTemperature(-269.9)).toBe(-269.9)
+  })
+})

--- a/src/device/meater.ts
+++ b/src/device/meater.ts
@@ -171,17 +171,39 @@ export class Meater extends deviceBase {
   }
 
   /**
+   * Clamp temperature values to HomeKit's valid range (-270°C to 100°C)
+   */
+  private clampTemperature(temperature: number, sensorType: string): number {
+    const minTemp = -270
+    const maxTemp = 100
+
+    if (temperature > maxTemp) {
+      this.warnLog(`${sensorType} temperature ${temperature}°C exceeds HomeKit maximum (${maxTemp}°C), clamping to ${maxTemp}°C`)
+      return maxTemp
+    }
+
+    if (temperature < minTemp) {
+      this.warnLog(`${sensorType} temperature ${temperature}°C below HomeKit minimum (${minTemp}°C), clamping to ${minTemp}°C`)
+      return minTemp
+    }
+
+    return temperature
+  }
+
+  /**
    * Parse the device status from the SwitchBot api
    */
   async parseStatus(): Promise<void> {
     // Internal Temperature
-    this.Internal.CurrentTemperature = this.deviceStatus.data.temperature.internal
+    const rawInternalTemp = this.deviceStatus.data.temperature.internal
+    this.Internal.CurrentTemperature = this.clampTemperature(rawInternalTemp, 'Internal')
     if (this.Internal.CurrentTemperature !== this.accessory.context.Internal.CurrentTemperature) {
       this.infoLog(`Internal Current Temperature: ${this.Internal.CurrentTemperature}°c`)
     }
 
     // Ambient Temperature
-    this.Ambient.CurrentTemperature = this.deviceStatus.data.temperature.ambient
+    const rawAmbientTemp = this.deviceStatus.data.temperature.ambient
+    this.Ambient.CurrentTemperature = this.clampTemperature(rawAmbientTemp, 'Ambient')
     if (this.Ambient.CurrentTemperature !== this.accessory.context.Ambient.CurrentTemperature) {
       this.infoLog(`Ambient Current Temperature: ${this.Ambient.CurrentTemperature}°c`)
     }

--- a/src/device/meater.ts
+++ b/src/device/meater.ts
@@ -213,6 +213,9 @@ export class Meater extends deviceBase {
             await this.statusCode(statusCode)
             await this.statusCode(device.statusCode)
           }
+        } else {
+          this.errorLog('No authentication token available. Please restart Homebridge to re-authenticate with Meater API.')
+          this.CookRefresh.On = false
         }
       } catch (e: any) {
         this.apiError(e)

--- a/src/device/meater.ts
+++ b/src/device/meater.ts
@@ -140,7 +140,18 @@ export class Meater extends deviceBase {
       On: accessory.context.CookRefresh.On ?? false,
     }
     accessory.context.CookRefresh = this.CookRefresh as object
-
+    if (this.CookRefresh) {
+      if (!this.CookRefresh.Service) {
+        this.CookRefresh.Service = new this.hap.Service.Switch(this.CookRefresh.Name.toString(), this.CookRefresh.Name.toString())
+        if (this.CookRefresh.Service) {
+          this.CookRefresh.Service = this.accessory.addService(this.CookRefresh.Service)
+          this.debugLog(`${accessory.displayName} Cook Refresh Service`)
+        } else {
+          this.errorLog(`${accessory.displayName} Cook Refresh Service -- Failed!`)
+        }
+      }
+    }
+    // Add CookRefresh Switch Service's Characteristics
     this.CookRefresh.Service
       .setCharacteristic(this.hap.Characteristic.Name, this.CookRefresh.Name)
       .setCharacteristic(this.hap.Characteristic.On, this.CookRefresh.On)

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -165,6 +165,11 @@ export class MeaterPlatform implements DynamicPlatformPlugin {
         this.debugLog(`Login Token: ${JSON.stringify(login.data.token)}`)
         this.debugLog(`statusCode: ${statusCode} & devicesAPI StatusCode: ${login.statusCode}`)
         if (statusCode === 200 && login.statusCode === 200) {
+          this.infoLog('Successfully authenticated with Meater API')
+          // Save the token to config for future use
+          if (this.config.credentials) {
+            this.config.credentials.token = login.data.token
+          }
           const { body, statusCode } = await this.requestJson(meaterUrl, {
             method: 'GET',
             headers: {
@@ -178,6 +183,16 @@ export class MeaterPlatform implements DynamicPlatformPlugin {
           if (statusCode === 200 && device.statusCode === 200) {
             this.infoLog (`Found ${device.data.devices.length} Devices`)
             const deviceLists = device.data.devices
+            
+            // Log device IDs for user configuration (visible without debug mode)
+            if (deviceLists && deviceLists.length > 0) {
+              this.infoLog('Discovered Meater devices:')
+              deviceLists.forEach((device: any, index: number) => {
+                this.infoLog(`  Device ${index + 1}: ID = ${device.id}`)
+              })
+              this.infoLog('To configure specific devices, add these IDs to your config under options.devices')
+            }
+            
             await this.configureDevices(deviceLists)
             // Meater Devices
             /* device.data.devices.forEach((device: device & deviceConfig) => {
@@ -187,6 +202,11 @@ export class MeaterPlatform implements DynamicPlatformPlugin {
             this.statusCode(statusCode)
             this.statusCode(device.statusCode)
           }
+        } else {
+          // Login failed
+          this.errorLog('Failed to authenticate with Meater API')
+          this.statusCode(statusCode)
+          this.statusCode(login.statusCode)
         }
       }
     } catch (e: any) {
@@ -200,6 +220,10 @@ export class MeaterPlatform implements DynamicPlatformPlugin {
   private async configureDevices(deviceLists: any) {
     if (!this.config.options?.devices) {
       this.debugLog(`No Meater Device Config: ${JSON.stringify(this.config.options?.devices)}`)
+      if (deviceLists && deviceLists.length > 0) {
+        this.infoLog('Auto-discovering devices (no device configuration found)')
+        this.infoLog('For custom device names or settings, add device IDs to your configuration')
+      }
       const devices = deviceLists.map((v: any) => v)
       for (const device of devices) {
         await this.createMeter(device)


### PR DESCRIPTION
## [2.1.0](https://github.com/homebridge-plugins/homebridge-meater/releases/tag/v2.1.0) (2026-05-04)

## What's Changed
* chore(release): prepare v2.1.0 release groundwork
* chore(deps): housekeeping and lockfile maintenance
* feat(matter): add Homebridge Matter support with HAP fallback
* test(matter): add config-gated fallback and selection coverage
* refactor(http): replace undici with native Node HTTP(S) requests
* chore(release): align workflow, config, and changelog for v2.1.0
* fix(device): ensure Cook Refresh switch service is created before characteristic updates (PR #28, PR #33)
* fix(auth): improve API authentication flow, persist token, and improve discovery logging (PR #35)
* fix(temperature): clamp probe temperatures to HomeKit valid range to prevent characteristic validation errors (PR #36)
* test(device): add unit tests for temperature clamping behavior (PR #36)
* docs(workflow): add Copilot beta-branch workflow documentation (PR #34)

Automatic Matter selection now uses Homebridge runtime availability only, with HAP fallback when Matter is unavailable.

**Full Changelog**: https://github.com/homebridge-plugins/homebridge-meater/compare/v2.0.3...v2.1.0